### PR TITLE
fix: port corvia hooks infrastructure from corvia-workspace

### DIFF
--- a/.claude/commands/dev-loop.md
+++ b/.claude/commands/dev-loop.md
@@ -1,0 +1,22 @@
+Use the dev-loop skill from `.agents/skills/dev-loop/SKILL.md` to execute the full
+development lifecycle for the given GitHub issue.
+
+**Issue:** $ARGUMENTS
+
+## Instructions
+
+Read and follow `.agents/skills/dev-loop/SKILL.md` exactly. The skill defines 7 phases:
+
+1. **Issue Intake** — Fetch the issue with `gh issue view`, query corvia for context, create feature branch
+2. **Brainstorm & Design** — Invoke `superpowers:brainstorming` with the issue prompt
+3. **Implementation Plan** — Invoke `superpowers:writing-plans` from the approved design
+4. **Implementation** — Invoke `superpowers:subagent-driven-development` to execute the plan
+5. **5-Persona Review** — Dispatch 5 independent reviewer subagents (Senior SWE, PM, QA + 2 dynamic) using `.agents/skills/dev-loop/five-persona-reviewer.md` template. Loop fixes until all Critical/Important/Low issues resolved.
+6. **E2E Integration Test** — Test as a real user using `.agents/skills/dev-loop/e2e-tester.md`. Cover happy path, edge cases, integration points, regression.
+7. **Branch, PR, Merge** — Push, create PR with review summary, merge to master, resolve conflicts if any, cleanup branch, record in corvia.
+
+**Hard gates:** No phase can be skipped. Design must be approved before planning. All review issues (Critical through Low) must be fixed before merge. Tests must pass after conflict resolution.
+
+**Autonomy:** Proceed autonomously through all phases. Only pause to ask if the issue is ambiguous, brainstorming produces fundamentally different approaches, or merge conflicts are complex.
+
+Start now by announcing: "I'm using the dev-loop skill to work on issue #$ARGUMENTS."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,11 +2,19 @@
   "hooks": {
     "PostToolUse": [
       {
-        "_comment": "After git commits, remind to persist decisions/learnings to corvia knowledge base.",
         "hooks": [
           {
-            "command": "bash .claude/hooks/corvia-write-reminder.sh",
-            "timeout": 10000,
+            "command": "[ \"$CORVIA_HOOKS_DISABLED\" = \"1\" ] && exit 0; corvia hooks run --event PostToolUse 2>/tmp/.corvia-hook-err || { rc=$?; grep -q \"unrecognized subcommand\" /tmp/.corvia-hook-err 2>/dev/null && exit 0; cat /tmp/.corvia-hook-err >&2; exit $rc; }",
+            "timeout": 5000,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "[ \"$CORVIA_HOOKS_DISABLED\" = \"1\" ] && exit 0; corvia hooks run --event PostToolUse --handler write-reminder 2>/tmp/.corvia-hook-err || { rc=$?; grep -q \"unrecognized subcommand\" /tmp/.corvia-hook-err 2>/dev/null && exit 0; cat /tmp/.corvia-hook-err >&2; exit $rc; }",
+            "timeout": 5000,
             "type": "command"
           }
         ],
@@ -17,28 +25,39 @@
       {
         "hooks": [
           {
-            "command": "echo 'REMINDER: Have you called corvia_search or corvia_ask first? Per CLAUDE.md, you MUST query corvia MCP tools (scope_id: dorea) before using Grep/Glob for any new task or question. If you already called corvia this session, proceed.'",
+            "command": "[ \"$CORVIA_HOOKS_DISABLED\" = \"1\" ] && exit 0; corvia hooks run --event PreToolUse 2>/tmp/.corvia-hook-err || { rc=$?; grep -q \"unrecognized subcommand\" /tmp/.corvia-hook-err 2>/dev/null && exit 0; cat /tmp/.corvia-hook-err >&2; exit $rc; }",
+            "timeout": 5000,
             "type": "command"
           }
-        ],
-        "matcher": "Grep|Glob"
+        ]
       },
       {
         "hooks": [
           {
-            "command": "bash .corvia/hooks/doc-placement-check.sh",
+            "command": "[ \"$CORVIA_HOOKS_DISABLED\" = \"1\" ] && exit 0; corvia hooks run --event PreToolUse --handler doc-placement 2>/tmp/.corvia-hook-err || { rc=$?; grep -q \"unrecognized subcommand\" /tmp/.corvia-hook-err 2>/dev/null && exit 0; cat /tmp/.corvia-hook-err >&2; exit $rc; }",
+            "timeout": 5000,
             "type": "command"
           }
         ],
         "matcher": "Write|Edit"
+      },
+      {
+        "hooks": [
+          {
+            "command": "[ \"$CORVIA_HOOKS_DISABLED\" = \"1\" ] && exit 0; corvia hooks run --event PreToolUse --handler corvia-first-reminder 2>/tmp/.corvia-hook-err || { rc=$?; grep -q \"unrecognized subcommand\" /tmp/.corvia-hook-err 2>/dev/null && exit 0; cat /tmp/.corvia-hook-err >&2; exit $rc; }",
+            "timeout": 5000,
+            "type": "command"
+          }
+        ],
+        "matcher": "Grep|Glob"
       }
     ],
     "SessionEnd": [
       {
-        "_comment": "WORKAROUND: Claude Code leaks memory via orphaned node processes in WSL. Kills orphans on session exit. Remove when upstream fix lands.",
         "hooks": [
           {
-            "command": "bash \"$CORVIA_WORKSPACE/.devcontainer/scripts/cleanup-orphans.sh\" --quiet 2>/dev/null || true",
+            "command": "[ \"$CORVIA_HOOKS_DISABLED\" = \"1\" ] && exit 0; corvia hooks run --event SessionEnd 2>/tmp/.corvia-hook-err || { rc=$?; grep -q \"unrecognized subcommand\" /tmp/.corvia-hook-err 2>/dev/null && exit 0; cat /tmp/.corvia-hook-err >&2; exit $rc; }",
+            "timeout": 30000,
             "type": "command"
           }
         ]
@@ -46,10 +65,20 @@
     ],
     "SessionStart": [
       {
-        "_comment": "Display-only reminder for agent identity selection.",
         "hooks": [
           {
-            "command": "bash .claude/hooks/agent-check.sh",
+            "command": "[ \"$CORVIA_HOOKS_DISABLED\" = \"1\" ] && exit 0; corvia hooks run --event SessionStart 2>/tmp/.corvia-hook-err || { rc=$?; grep -q \"unrecognized subcommand\" /tmp/.corvia-hook-err 2>/dev/null && exit 0; cat /tmp/.corvia-hook-err >&2; exit $rc; }",
+            "timeout": 5000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "[ \"$CORVIA_HOOKS_DISABLED\" = \"1\" ] && exit 0; corvia hooks run --event UserPromptSubmit 2>/tmp/.corvia-hook-err || { rc=$?; grep -q \"unrecognized subcommand\" /tmp/.corvia-hook-err 2>/dev/null && exit 0; cat /tmp/.corvia-hook-err >&2; exit $rc; }",
             "timeout": 5000,
             "type": "command"
           }

--- a/.devcontainer/scripts/lib.sh
+++ b/.devcontainer/scripts/lib.sh
@@ -534,6 +534,20 @@ install_claude_plugin() {
     local plugins_json="/root/.claude/plugins/installed_plugins.json"
     local cache_base="/root/.claude/plugins/cache/${marketplace}/${plugin_name}"
 
+    # Ensure workspace symlink so AI file search can find plugin skills.
+    # The plugin runtime injects skills via JS hook, but Claude (the AI model)
+    # also needs to read SKILL.md files during conversations — and it searches
+    # the workspace tree, not ~/.claude/plugins/cache/.
+    _link_plugin_skills() {
+        local target_skills="$1/skills"
+        local link_path="${WORKSPACE_ROOT}/.agents/skills/${plugin_name}"
+        if [ -d "$target_skills" ]; then
+            mkdir -p "$(dirname "$link_path")"
+            ln -sfn "$target_skills" "$link_path"
+            logm claude "${plugin_name}: linked skills → ${link_path}"
+        fi
+    }
+
     # Check if already installed by looking at installed_plugins.json
     if [ -f "$plugins_json" ] && python3 -c "
 import json, sys
@@ -544,6 +558,14 @@ if entries and entries[0].get('installPath'):
     sys.exit(0 if os.path.isdir(entries[0]['installPath']) else 1)
 sys.exit(1)
 " 2>/dev/null; then
+        # Plugin exists — still ensure the workspace symlink is current
+        local existing_path
+        existing_path=$(python3 -c "
+import json
+d = json.load(open('$plugins_json'))
+print(d['plugins']['$plugin_key'][0]['installPath'])
+" 2>/dev/null)
+        [ -n "$existing_path" ] && _link_plugin_skills "$existing_path"
         echo "already installed"
         return 0
     fi
@@ -591,6 +613,7 @@ d['plugins']['$plugin_key'] = [{
 }]
 json.dump(d, open(path, 'w'), indent=2)
 "
+    _link_plugin_skills "$install_path"
     echo "installed v${version}"
 }
 

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -41,6 +41,11 @@ step "Ingesting workspace into knowledge base"
 spin "Ingesting repos..." corvia workspace ingest \
     || echo "    ingest failed — run 'corvia workspace ingest' manually to populate knowledge base"
 
+step "Setting up hooks (git + doc-placement)"
+if command -v corvia >/dev/null 2>&1; then
+    corvia workspace init-hooks 2>/dev/null && echo "    hooks initialized" || echo "    hook init deferred (server not ready)"
+fi
+
 step "Ensuring tooling"
 ensure_tooling
 

--- a/corvia.toml
+++ b/corvia.toml
@@ -76,6 +76,15 @@ service_name = "dorea"
 log_format = "json"
 metrics_enabled = true
 
+[hooks]
+session_recording = true
+doc_placement = true
+agent_check = true
+write_reminder = true
+orphan_cleanup = true
+corvia_first_reminder = true
+agent_teams = true
+
 [inference]
 device = "cpu"
 kv_quant = "q8"


### PR DESCRIPTION
## Summary
- Replace hand-written bash hooks with `corvia hooks run` dispatcher
- Add `/dev-loop` slash command
- Add `[hooks]` config to `corvia.toml`
- Port `_link_plugin_skills` symlink for superpowers skills
- Add `corvia workspace init-hooks` to post-create.sh

## Changes
- **`.claude/settings.json`**: All hooks now use `corvia hooks run --event <event>` instead of bash scripts
- **`.claude/commands/dev-loop.md`**: New slash command for `/dev-loop <issue>`
- **`corvia.toml`**: Added `[hooks]` section enabling all 7 hook handlers
- **`.devcontainer/scripts/post-create.sh`**: Added `corvia workspace init-hooks` step
- **`.devcontainer/scripts/lib.sh`**: Added `_link_plugin_skills` to `install_claude_plugin`

## Test plan
- [x] `corvia hooks status` shows all hooks active (8 entries registered)
- [ ] New session auto-registers agent identity (requires session restart)
- [ ] `/dev-loop 14` resolves as a slash command
- [ ] `corvia_write` works without manual agent registration

Closes #15

Generated with [Claude Code](https://claude.com/claude-code)