### PR TITLE
feat: Dorea v2 Phase 1 — Rust workspace + core color/LUT/HSL/calibration

### DIFF
--- a/.corvia/knowledge/dorea/019d4b8d-8cc8-7430-992a-7ffae49cae88.json
+++ b/.corvia/knowledge/dorea/019d4b8d-8cc8-7430-992a-7ffae49cae88.json
@@ -1,0 +1,31 @@
+{
+  "id": "019d4b8d-8cc8-7430-992a-7ffae49cae88",
+  "content": "# Dorea v2 Architecture — Key Design Decisions (2026-04-02)\n\n## Issue\nchunzhe10/dorea-workspace#24 — \"Dorea v2: Rust+PyTorch pipeline rewrite for 4K video\"\n\n## Decision: Rust binary + PyTorch subprocess (not pure Rust, not pure Python)\n**Why:** PyTorch is essential for Video Depth Anything (temporal state, CVPR 2025) and RAUNE-Net inference. Pure Rust cannot replace torch.compile optimizations or the temporal recurrence in VDA. But core grading (LUT, HSL, color math, video I/O) in Rust gives near-native performance and eliminates DaVinci Resolve dependency.\n\n## Decision: CUDA compute kernels (not wgpu) for GPU grading\n**Why:** wgpu uses Vulkan backend; PyTorch uses CUDA. They cannot share the same GPU device without explicit VK_KHR_external_memory interop (which wgpu doesn't support). CUDA compute `.cu` kernels called from Rust via cuLaunchKernel live in the same CUDA memory space as PyTorch tensors — no copy needed. This unblocks the async depth→grade pipeline.\n**Alternative rejected:** wgpu (GPU interop impossible with CUDA PyTorch). Serialized GPU access (possible fallback but kills async benefit).\n\n## Decision: Phase 1 CPU-only, no DaVinci Resolve\n**Why:** Phase 1 validates all color math and calibration workflow on CPU before adding CUDA complexity. `--cpu-only` mode serves as both test fallback and portability option.\n**DaVinci Resolve dropped entirely:** The v2 pipeline is self-contained. No Resolve import, no DRX templates, no host-machine script.\n\n## Decision: dorea-color, dorea-lut, dorea-hsl, dorea-cal, dorea-video crate split\n**Why:** Color math (dorea-color) is pure functions with no deps. LUT building (dorea-lut) and HSL correction (dorea-hsl) have separate concerns and test surfaces. Calibration format (dorea-cal) needs serde/bincode separately. This was flagged in 5-persona review — monolithic dorea-core was rejected.\n\n## Decision: Legacy Python code archived as `legacy/v1` branch\n**Why:** 90%+ of existing Python scripts (00-05, SAM2, Resolve) are dead code in v2. Archiving preserves history without polluting main. Branch `legacy/v1` pushed to origin on 2026-04-02.\n\n## Alternatives rejected\n- WaterNet/Sea-thru: replaced by RAUNE-Net (better generalization, lower hue error)\n- SAM2 tracking: depth maps suffice for per-depth correction without per-subject masks\n- DaVinci Resolve: eliminated, fully code-based pipeline\n- Global σ=1 Gaussian LUT smoothing: was the primary cause of 9.8° hue shift — σ=0 required\n",
+  "source_version": "mcp",
+  "scope_id": "dorea",
+  "workstream": "main",
+  "recorded_at": "2026-04-02T00:17:41.064412582Z",
+  "valid_from": "2026-04-02T00:17:41.064412582Z",
+  "valid_to": null,
+  "superseded_by": null,
+  "metadata": {
+    "source_file": null,
+    "language": null,
+    "chunk_type": null,
+    "start_line": null,
+    "end_line": null,
+    "content_role": "decision",
+    "source_origin": "repo:dorea"
+  },
+  "agent_id": "claude-code",
+  "session_id": "claude-code/sess-e1aa836c",
+  "entry_status": "Pending",
+  "memory_type": "episodic",
+  "confidence": null,
+  "last_accessed": null,
+  "access_count": 0,
+  "tier": "hot",
+  "tier_changed_at": null,
+  "retention_score": null,
+  "pin": null
+}

--- a/.corvia/knowledge/dorea/019d4bae-1ef5-7ca1-8607-344dfc62097b.json
+++ b/.corvia/knowledge/dorea/019d4bae-1ef5-7ca1-8607-344dfc62097b.json
@@ -1,0 +1,31 @@
+{
+  "id": "019d4bae-1ef5-7ca1-8607-344dfc62097b",
+  "content": "# Dorea v2 Phase 1 — Review Insights (2026-04-02)\n\n## Patterns validated\n- **f64 for D-Log M math, f32 for pixels**: Correct. Transcendental curves need f64; pixel arrays are fine as f32.\n- **LUT accumulation in f64**: Correct. `lut_wsum`/`lut_wcount` as Vec<f64> avoids catastrophic cancellation summing millions of small weights.\n- **`total_cmp()` instead of `partial_cmp().unwrap()`** for sorting f32 depth slices: Rust 1.62+ builtin, NaN-safe.\n\n## Patterns to avoid\n- **env_logger::init() before argument parsing**: `set_var(\"RUST_LOG\", ...)` after `init()` has zero effect. Initialize with `env_logger::Builder::from_env().filter_level(...)` AFTER parsing args.\n- **Fixed `zone_width = 1/n_zones` against adaptive zone centers**: When using adaptive quantile zone boundaries, the blending radius must come from `zone_boundaries[z+1] - zone_boundaries[z]`, not a fixed `1/n_zones`. Mismatch silently prevents corrections from reaching pixels outside the training depth distribution.\n- **`partial_cmp().unwrap()` in sort_by on f32**: Panics on NaN. Always use `total_cmp()`.\n- **Bincode full deserialization before version check**: The version field cannot be read after struct layout has changed. Read the first raw byte before full deserialization.\n- **Library `assert_eq!` without context**: Always include message strings: `assert_eq!(a, b, \"context: a={}, b={}\", a, b)`.\n- **Declaring `rayon` in Cargo.toml but not using it**: Either use it or remove it. `cargo check` won't warn.\n\n## Reusable knowledge for future crates\n- **HSL qualifier aggregation across keyframes**: Weight by `corr.weight` (qualifier's actual pixel coverage), not by total frame pixel count. A 4K frame where only 50 cyan pixels exist should not outweigh a 720p frame with 200K cyan pixels.\n- **`usize` subtraction with N-1 pattern**: Always guard with `.saturating_sub(1)` or early empty check. `n - 1` where `n: usize = 0` wraps to `usize::MAX` in release mode.\n- **`zip()` silent truncation**: `iter.zip(other_iter)` silently truncates to shorter slice. For pixel arrays that must be same length, add an upfront `assert_eq!` with context.\n",
+  "source_version": "mcp",
+  "scope_id": "dorea",
+  "workstream": "main",
+  "recorded_at": "2026-04-02T00:53:15.637679725Z",
+  "valid_from": "2026-04-02T00:53:15.637679725Z",
+  "valid_to": null,
+  "superseded_by": null,
+  "metadata": {
+    "source_file": null,
+    "language": null,
+    "chunk_type": null,
+    "start_line": null,
+    "end_line": null,
+    "content_role": "learning",
+    "source_origin": "repo:dorea"
+  },
+  "agent_id": "claude-code",
+  "session_id": "claude-code/sess-e1aa836c",
+  "entry_status": "Pending",
+  "memory_type": "episodic",
+  "confidence": null,
+  "last_accessed": null,
+  "access_count": 0,
+  "tier": "hot",
+  "tier_changed_at": null,
+  "retention_score": null,
+  "pin": null
+}

--- a/.corvia/knowledge/dorea/019d4bb0-2c1b-7343-a7a6-c3c9b62433de.json
+++ b/.corvia/knowledge/dorea/019d4bb0-2c1b-7343-a7a6-c3c9b62433de.json
@@ -1,0 +1,31 @@
+{
+  "id": "019d4bb0-2c1b-7343-a7a6-c3c9b62433de",
+  "content": "# Dorea v2 Phase 1 — Final Decision Record (2026-04-02)\n\n## What\nImplemented Phase 1 of the Dorea v2 Rust rewrite: Cargo workspace with 6 crates (dorea-color, dorea-lut, dorea-hsl, dorea-cal, dorea-video stub, dorea-cli). Deleted all Python pipeline scripts. `dorea calibrate` command is fully functional.\n\n## GitHub\nchunzhe10/dorea-workspace#24, branch: feat/24-dorea-v2-rust-rewrite (workspace) + dorea main commits `3e6ac98` + `0968c97`\n\n## Key Design Decisions Made\n\n1. **`zone_width` for LUT blending must use per-zone adaptive width, NOT `1/n_zones`**: When adaptive quantile zone boundaries are used, the blending radius must come from `zone_boundaries[z+1] - zone_boundaries[z]`. Fixed width produces silent passthrough for pixels outside the training depth distribution.\n\n2. **`--input-encoding srgb|dlog_m` flag**: Phase 1 accepts pre-computed RAUNE-Net targets. Keyframes must be in the same encoding as what RAUNE-Net receives. Added explicit flag rather than auto-detecting.\n\n3. **calibration format version = 2**: Bumped from v1 when changing `created_at: String` to `created_at_unix_secs: u64`. First byte is the version; checked before full bincode deserialization.\n\n4. **Calibration file size** = exactly `n_zones × LUT_SIZE³ × 3 × sizeof(f32) + overhead` = 2.06 MB for 5-zone 33³ LUT. Real-data verification: 3 POC keyframes (3840×2160 JPEG, depth 924×518) produced a 2,156,589-byte .dorea-cal with physically plausible HSL corrections (Blue: -0.36°, Cyan: -4.46° — underwater blue/cyan dominance as expected).\n\n## What Blocked / Surprised\n\n- **env_logger initialized before verbose flag parsed**: Classic Rust CLI gotcha. `env_logger::init()` reads `RUST_LOG` once at call time. Must parse the `verbose` flag first, then initialize the logger with an explicit `LevelFilter`. `std::env::set_var(\"RUST_LOG\", ...)` after init is silently ignored.\n\n- **Adaptive zone boundaries + fixed zone_width mismatch**: This is a subtle but important bug class. Building with adaptive boundaries and blending with fixed width are inconsistent. The fix requires threading per-zone widths from the build step through to the apply step via `DepthLuts`.\n\n- **`usize` subtraction in `n - 1` pattern**: `n.saturating_sub(1)` should always be used when `n` can be 0. Regular subtraction wraps to `usize::MAX` in release mode with no panic.\n\n## Phase 2 Next Steps\n- Python subprocess for RAUNE-Net and Video Depth Anything inference\n- IPC protocol between Rust and Python (shared memory + semaphores)\n- CUDA compute kernels for fused LUT+HSL+grading pipeline (replaces wgpu)\n- `dorea grade` CLI command (video in → video out)\n",
+  "source_version": "mcp",
+  "scope_id": "dorea",
+  "workstream": "main",
+  "recorded_at": "2026-04-02T00:55:30.075635639Z",
+  "valid_from": "2026-04-02T00:55:30.075635639Z",
+  "valid_to": null,
+  "superseded_by": null,
+  "metadata": {
+    "source_file": null,
+    "language": null,
+    "chunk_type": null,
+    "start_line": null,
+    "end_line": null,
+    "content_role": "decision",
+    "source_origin": "repo:dorea"
+  },
+  "agent_id": "claude-code",
+  "session_id": "claude-code/sess-e1aa836c",
+  "entry_status": "Pending",
+  "memory_type": "episodic",
+  "confidence": null,
+  "last_accessed": null,
+  "access_count": 0,
+  "tier": "hot",
+  "tier_changed_at": null,
+  "retention_score": null,
+  "pin": null
+}

--- a/docs/plans/2026-04-02-dorea-v2-phase1-plan.md
+++ b/docs/plans/2026-04-02-dorea-v2-phase1-plan.md
@@ -1,0 +1,300 @@
+# Dorea v2 — Phase 1 Implementation Plan
+**Date:** 2026-04-02
+**Issue:** chunzhe10/dorea-workspace#24
+**Branch:** feat/24-dorea-v2-rust-rewrite (workspace), main (dorea repo)
+**Scope:** Cargo workspace + core algorithms + `dorea calibrate` CLI
+
+---
+
+## Goal
+
+Implement a working `dorea calibrate` command that:
+1. Accepts keyframe images + depth maps + RAUNE-Net target images
+2. Builds depth-stratified LUTs (σ=0, NN fill, importance-weighted, adaptive zone boundaries)
+3. Derives global HSL qualifier corrections
+4. Saves a `.dorea-cal` calibration file
+
+All CPU-only. No CUDA, no Python inference, no video I/O in Phase 1.
+
+---
+
+## Cargo Workspace Structure
+
+```
+repos/dorea/
+├── Cargo.toml              # workspace manifest
+├── Cargo.lock
+├── README.md               # updated for v2
+├── crates/
+│   ├── dorea-cli/          # binary: dorea grade/calibrate/preview
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── main.rs
+│   │       └── calibrate.rs
+│   ├── dorea-color/        # pure color math (no external deps)
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── lib.rs
+│   │       ├── dlog_m.rs   # D-Log M ↔ linear
+│   │       ├── lab.rs      # RGB ↔ CIELAB (D65)
+│   │       └── hsv.rs      # RGB ↔ HSV
+│   ├── dorea-lut/          # depth-stratified LUT build + apply
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── lib.rs
+│   │       ├── types.rs    # LutGrid, DepthLuts
+│   │       ├── build.rs    # build_depth_luts (importance weighting, NN fill)
+│   │       └── apply.rs    # apply_depth_luts (trilinear + depth blending)
+│   ├── dorea-hsl/          # HSL 6-vector qualifier correction
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── lib.rs
+│   │       ├── qualifiers.rs
+│   │       ├── derive.rs   # derive_hsl_corrections
+│   │       └── apply.rs    # apply_hsl_corrections
+│   ├── dorea-cal/          # calibration file format
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── lib.rs
+│   │       └── format.rs   # Calibration struct, save/load (bincode)
+│   └── dorea-video/        # stub (Phase 2: ffmpeg subprocess)
+│       ├── Cargo.toml
+│       └── src/
+│           └── lib.rs
+└── python/                 # stub (Phase 2: VDA + RAUNE-Net subprocess)
+    └── dorea_inference/
+        └── __init__.py
+```
+
+---
+
+## Crate Dependencies
+
+| Crate | External Deps |
+|-------|---------------|
+| dorea-color | — (pure math) |
+| dorea-lut | dorea-color |
+| dorea-hsl | dorea-color |
+| dorea-cal | serde, bincode, dorea-lut, dorea-hsl |
+| dorea-cli | clap, image, dorea-color, dorea-lut, dorea-hsl, dorea-cal |
+| dorea-video | — (stub) |
+
+---
+
+## Algorithm Specifications
+
+### 1. D-Log M Transfer Function (`dorea-color/src/dlog_m.rs`)
+
+Port from `pipeline_utils.py`:
+
+```
+a = 0.9892, b = 0.0108, c = 0.256663, d = 0.584555
+cut_encoded = 0.14
+cut_linear = (10^((cut_encoded - d) / c) - b) / a
+slope = c * a / ((a * cut_linear + b) * ln(10))
+intercept = cut_encoded - slope * cut_linear
+
+decode(x):
+  if x <= cut_encoded: (x - intercept) / slope
+  else: (10^((x - d) / c) - b) / a
+
+encode(x):
+  if x <= cut_linear: slope * x + intercept
+  else: c * log10(a * x + b) + d
+```
+
+Both operate on f32 pixel values [0,1].
+
+### 2. RGB ↔ CIELAB D65 (`dorea-color/src/lab.rs`)
+
+Standard conversion chain:
+1. sRGB → linear RGB (IEC 61966-2-1 precise piecewise)
+2. Linear RGB → XYZ (D65, ITU-R BT.709 matrix)
+3. XYZ → LAB (CIE 1976, D65 whitepoint Xn=0.95047, Yn=1.0, Zn=1.08883)
+
+Port from `ambiance_grade.py`'s `rgb_to_lab` / `lab_to_rgb`.
+
+### 3. RGB ↔ HSV (`dorea-color/src/hsv.rs`)
+
+Standard algorithm. H in [0,360), S in [0,1], V in [0,1].
+Input/output RGB in [0,1].
+
+### 4. Depth-Stratified LUT Build (`dorea-lut/src/build.rs`)
+
+Port from `run_fixed_hsl_lut_poc.py::build_fixed_depth_luts()`.
+
+**Constants:**
+- `LUT_SIZE = 33`
+- `N_DEPTH_ZONES = 5`
+- `EDGE_SCALE = 0.3`
+- `CONTRAST_SCALE = 0.3`
+
+**Zone boundaries:** Adaptive density-weighted (not linear linspace).
+- Pool all depth values from all keyframes
+- Sort and compute percentile boundaries so each zone covers ~20% of pixels
+- Fall back to linspace if depth distribution is degenerate
+
+**Per-keyframe:**
+1. Load original (sRGB) + RAUNE target (sRGB) + depth map (f32 [0,1])
+2. Compute importance map = depth × (1 + EDGE_SCALE × edge_norm) × (1 + CONTRAST_SCALE × contrast_norm)
+   - Edge: Sobel gradient of depth map
+   - Contrast: local variance of depth map (31×31 window)
+3. For each depth zone [lo, hi]:
+   - Mask pixels in zone
+   - Bin original pixels into 33³ grid (floor index)
+   - Accumulate: `lut_wsum[r,g,b] += raune_rgb × importance`; `lut_wcount[r,g,b] += importance`
+4. Normalize: `lut[r,g,b] = lut_wsum / lut_wcount` for populated cells
+5. NN fill for empty cells:
+   - Collect populated (i,j,k) coords
+   - For each empty cell, find nearest populated cell in L2 distance (brute force — N=33 is small)
+   - Fill with that cell's value
+
+**No Gaussian smoothing (σ=0). Critical fix.**
+
+### 5. LUT Application (`dorea-lut/src/apply.rs`)
+
+**Trilinear interpolation:**
+- For each pixel (r,g,b) ∈ [0,1]³:
+  - Scaled = (r,g,b) × (LUT_SIZE - 1)
+  - Floor indices (i0,j0,k0) + fractions (fr,fg,fb)
+  - 8-corner trilinear interpolation
+
+**Depth-weighted blending:**
+- Compute soft zone weights: `weight_z = max(1 - |depth - zone_center_z| / zone_width, 0)` for each zone z
+- Apply each zone's LUT to get `result_z`
+- `result = Σ(result_z × weight_z) / Σ(weight_z)`
+
+### 6. HSL Qualifier Derivation (`dorea-hsl/src/derive.rs`)
+
+Port from `run_fixed_hsl_lut_poc.py::derive_hsl_corrections()`.
+
+**6 qualifiers:**
+```
+Red/Skin:  h_center=0,   h_width=40
+Yellow:    h_center=40,  h_width=40
+Green:     h_center=100, h_width=50
+Cyan:      h_center=170, h_width=40
+Blue:      h_center=210, h_width=40
+Magenta:   h_center=290, h_width=50
+```
+
+**Per qualifier:**
+1. Soft mask: `w = max(1 - angular_dist(H, h_center) / h_width, 0.0) × (S > 0.08)`
+2. Skip if `total_weight < 100`
+3. `h_offset = weighted_circular_mean(H_target - H_lut)`
+4. `s_ratio = weighted_mean(S_target) / weighted_mean(S_lut)`
+5. `v_offset = weighted_mean(V_target - V_lut)` (in [0,1] units)
+
+### 7. HSL Qualifier Application (`dorea-hsl/src/apply.rs`)
+
+Port from `run_fixed_hsl_lut_poc.py::apply_hsl_corrections()`.
+
+For each pixel:
+1. Convert to HSV
+2. For each qualifier with weight ≥ 100:
+   - Compute soft mask (same as derivation)
+   - `H += h_offset × mask`
+   - `S = S × (1 + (s_ratio - 1) × mask)`, clamped [0,1]
+   - `V += v_offset × mask`, clamped [0,1]
+3. Wrap H to [0,360), clamp S and V
+4. Convert back to RGB
+
+### 8. Calibration Format (`dorea-cal/src/format.rs`)
+
+Binary format via `bincode` + `serde`:
+
+```rust
+struct Calibration {
+    version: u8,           // format version (current: 1)
+    lut_size: u8,          // 33
+    n_zones: u8,           // 5
+    zone_boundaries: [f32; 6],  // adaptive zone edges [0,1]
+    depth_luts: Vec<LutGrid>,   // n_zones LUTs, each 33³×3
+    hsl_corrections: HslCorrections,
+    created_at: String,    // ISO 8601
+    keyframe_count: u8,
+}
+```
+
+File extension: `.dorea-cal`
+
+### 9. CLI — `dorea calibrate` (`dorea-cli/src/calibrate.rs`)
+
+```
+dorea calibrate
+  --keyframes <dir>   Directory of sRGB PNG keyframes
+  --depth <dir>       Directory of 16-bit PNG depth maps (matched by name stem)
+  --targets <dir>     Directory of RAUNE-Net output PNGs (Phase 1: pre-computed)
+  --output <path>     Output .dorea-cal file [default: calibration.dorea-cal]
+  --cpu-only          No-op in Phase 1 (placeholder for Phase 2 GPU path)
+  -v / --verbose      Enable debug logging
+```
+
+**Matching:** keyframe `foo.png` → depth `foo.png` + target `foo.png` (by stem).
+
+---
+
+## Testing Strategy
+
+### Unit Tests (per crate)
+
+- `dorea-color`: round-trip tests (D-Log M encode→decode recovers input; RGB→LAB→RGB round-trip within tolerance)
+- `dorea-lut`: build with synthetic data (solid-color keyframes where LUT should be identity-ish); apply tests with known input/output
+- `dorea-hsl`: derivation with synthetic same-image (should give zero corrections); application with known offsets
+- `dorea-cal`: serialize→deserialize round-trip
+
+### Golden-File Tests
+
+`dorea-lut/tests/golden.rs` and `dorea-hsl/tests/golden.rs`:
+- Use the 3 keyframes from `working/sea_thru_poc/frames/` as reference
+- Compare Rust LUT output against Python reference within 1-2 LSB at 8-bit
+
+**Note:** Golden files (expected outputs) must be generated by running the Python POC once and saving outputs. Add a `regenerate_goldens` flag or separate script for this.
+
+---
+
+## Tasks
+
+### Task 1: Workspace manifest + crate scaffolding
+- Create `Cargo.toml` (workspace)
+- Scaffold all 6 crate `Cargo.toml` files and `src/lib.rs` stubs
+
+### Task 2: `dorea-color` — color math
+- `dlog_m.rs`: D-Log M encode/decode
+- `lab.rs`: RGB↔LAB
+- `hsv.rs`: RGB↔HSV
+- Unit tests for round-trips
+
+### Task 3: `dorea-lut` — LUT build + apply
+- `types.rs`: LutGrid, DepthLuts
+- `build.rs`: build_depth_luts (importance weighting, adaptive zones, NN fill, σ=0)
+- `apply.rs`: apply_depth_luts (trilinear + depth blending)
+- Unit tests
+
+### Task 4: `dorea-hsl` — HSL qualifier correction
+- `qualifiers.rs`: HSL_QUALIFIERS constants
+- `derive.rs`: derive_hsl_corrections
+- `apply.rs`: apply_hsl_corrections
+- Unit tests
+
+### Task 5: `dorea-cal` — calibration format
+- `format.rs`: Calibration struct, save/load
+- Round-trip test
+
+### Task 6: `dorea-cli` — calibrate command
+- `main.rs`: CLI entry with clap
+- `calibrate.rs`: orchestration (load images → build LUTs → derive HSL → save .dorea-cal)
+- Integration test: run with sample data, verify .dorea-cal is readable
+
+### Task 7: Remove dead code + update README
+- Delete old Python scripts from main branch
+- Update README to describe v2 architecture
+
+---
+
+## Constraints
+
+- RTX 3060 6GB VRAM — Phase 1 is CPU only, no VRAM constraint
+- No DaVinci Resolve dependency in Phase 1+
+- All tests must pass with `cargo test`
+- Clippy clean: `cargo clippy -- -D warnings`


### PR DESCRIPTION
## Summary

- Implements Phase 1 of issue #24: Rust rewrite of the Dorea underwater video pipeline
- Archives Python v1 pipeline as `legacy/v1` branch in `chunzhe10/dorea`
- Ships working `dorea calibrate` CLI command — first milestone toward fully code-based 4K color grading

## Changes

**In `chunzhe10/dorea` (Rust rewrite, 2 commits):**
- `dorea-color`: D-Log M ↔ linear, sRGB ↔ CIELAB, RGB ↔ HSV — pure color math, no deps
- `dorea-lut`: Depth-stratified 33³ LUT build (σ=0, NN fill, adaptive zone boundaries, importance weighting) + trilinear apply with depth blending
- `dorea-hsl`: 6-vector HSL qualifier correction (DaVinci-style) — derive + apply
- `dorea-cal`: `.dorea-cal` binary format (bincode v2) with version check before deserialization
- `dorea-cli`: `dorea calibrate --keyframes ... --depth ... --targets ... [--input-encoding dlog_m|srgb]`
- `dorea-video`: Phase 2 stub (ffmpeg NVDEC/NVENC)
- Deleted all Python pipeline scripts, requirements.txt, Resolve templates

**In this workspace repo:**
- `docs/plans/2026-04-02-dorea-v2-phase1-plan.md`: Phase 1 implementation plan
- Corvia knowledge: architecture decisions, review insights, final decision record

## Test Plan

- [x] 14 unit tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [x] E2E: `dorea calibrate` on 3 real POC keyframes (3840×2160 JPEG → PNG, depth 924×518) produces 2.06 MB `.dorea-cal` (exact match for 5×33³×3×f32 LUT)
- [x] HSL corrections physically plausible: Blue -0.36°, Cyan -4.46° (underwater blue/cyan dominance)
- [x] Error handling: empty dir, missing files, `--verbose` flag, `--input-encoding dlog_m`
- [x] Calibration file: version byte=2, loads correctly

## Review

5-persona review completed:
- **Senior SWE**: With fixes — zone_width mismatch, usize underflow, verbose bug (all fixed)
- **Product Manager**: With fixes — verbose flag, README Resolve mention, targets docs (all fixed)
- **QA Engineer**: With fixes — truncation assert, NaN sort, test coverage (all fixed, 14 tests)
- **Rust Idiom Reviewer**: With fixes — rayon unused, assert context, zone_width (all fixed)
- **Color Science Reviewer**: With fixes — D-Log M decode flag, zone_width, NN fill comment (all fixed)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)